### PR TITLE
Typo in regexes.pod

### DIFF
--- a/src/regexes.pod
+++ b/src/regexes.pod
@@ -779,7 +779,7 @@ X<regex, zero-width assertion>
 The word character after the comma is not part of the match, because it is in
 a look-ahead introduced by C<< <?before ... > >>. The leading question mark
 indicates an I<zero-width assertion>: a rule that never consumes characters
-from the matched string.  You can turn any call to a subrule into an zero
+from the matched string.  You can turn any call to a subrule into a zero
 width assertion.  The built-in token C<< <alpha> >> matches an alphabetic
 character, so you can rewrite this example as:
 


### PR DESCRIPTION
Just fixed what I believe is a typo in regexes.pod. Only 1 line is changed.

Regards,
