### PR TITLE
A small spelling mistake corrected.

### DIFF
--- a/src/basics.pod
+++ b/src/basics.pod
@@ -1,6 +1,6 @@
 =head0 The Basics
 
-Z:<sec:basics>
+Z<sec:basics>
 
 Perl originated as a programming language intended to gather and summarize
 information from text files.  It's still strong in text processing, but Perl 5


### PR DESCRIPTION
What was "Z:<sec:basics>" has now become "Z<sec:basics>".
