### PR TITLE
This fixes the Pod error: '=item' outside of any '=over'.

### DIFF
--- a/authors.pod
+++ b/authors.pod
@@ -1,6 +1,10 @@
+=pod
+
 =head1 Authors
 
 This book is the work of many contributors.  They are listed below.
+
+=over 4
 
 =item Jonathan Worthington
 
@@ -26,3 +30,7 @@ anything related to Perl 6.
 Scott occasionally tries to write things in Perl 6, but mostly hangs out
 on irc.freenode.net on the #perl6 channel and discusses anything that
 piques his interest relating to Perl 6 or its development.
+
+=back
+
+=cut


### PR DESCRIPTION
This fixes the pod errors, i.e.,

POD ERRORS

Hey! The above document had some coding errors, which are explained below:

Around line 5:

```
'=item' outside of any '=over'
```

in 'authors.pod'.
